### PR TITLE
Add semantic_version as a direct dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: python-v{{ version }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip {{ pip }}
     - python {{ python }}
     - rust-nightly {{ rust_nightly }}
+    - semantic_version # [py<37]
     - setuptools-rust {{ setuptools_rust }}
   run:
     - python {{ python }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

For Python 3.6, semantic_versioning is needed by setuptools-rust (from upstream channel). If we won't add it as a direct dependency here, the build tools won't know that semantic_versioning needs to be built before tokenizers.

I didn't pin a version yet, because I don't think it is really needed, and it might make building things a little more difficult due to the conda_build_config file moving locations.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
